### PR TITLE
Cache access control permissions for one day

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -10,6 +10,7 @@ function withCors(fn: (req: IncomingMessage, res: ServerResponse) => void) {
       "Access-Control-Allow-Headers",
       "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
     );
+    res.setHeader("Access-Control-Max-Age", 86400);
     if (req.method === "OPTIONS") {
       res.end();
     } else {


### PR DESCRIPTION
Allows API request without an [OPTIONS][0] preflight each time.

[0]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS